### PR TITLE
Get rid of bower install warning when using the Angular 1.4 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For an example see [test/index.html](https://github.com/fmquaglia/ngOrderObjectB
 
 ##Tests
 
-You need [karma](https://www.npmjs.org/package/karma), [karma-jasmine](https://www.npmjs.org/package/karma-jasmine), [phantomjs](https://www.npmjs.org/package/phantomjs), [karma-phantom-js-launcher](https://www.npmjs.org/package/karma-phantomjs-launcher) and [angular-mocks](https://www.npmjs.org/package/angular-mocks) in order to run the tests.
+You need [karma](https://www.npmjs.org/package/karma), [karma-cli](https://www.npmjs.com/package/karma-cli), [karma-jasmine](https://www.npmjs.org/package/karma-jasmine), [phantomjs](https://www.npmjs.org/package/phantomjs), [karma-phantom-js-launcher](https://www.npmjs.org/package/karma-phantomjs-launcher) and [angular-mocks](https://www.npmjs.org/package/angular-mocks) in order to run the tests.
 
 ```karma start karma.conf.js ```
 

--- a/bower.json
+++ b/bower.json
@@ -21,9 +21,9 @@
     "test"
   ],
   "dependencies": {
-    "angular": "~1.3.11"
+    "angular": "^1.3.11-1.5"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.11"
+    "angular-mocks": "^1.3.11-1.5"
   }
 }


### PR DESCRIPTION
* Changed the bower versions of angular and angular-mocks to accept versions from 1.3.11 (the previous accepted angular version) to < 1.5

* Added karma-cli as a test dependency to the README

This fixes Issue #10 
