### PR TITLE
Allow direction comparator to be explicitly set to 'ascending'

### DIFF
--- a/src/ng-order-object-by.js
+++ b/src/ng-order-object-by.js
@@ -40,8 +40,8 @@
 
             return comparator;
           });
-
-          if (reverse) {
+          
+          if (reverse && reverse !== 'asc' && reverse !== 'ascending' && reverse !== false) {
             filtered.reverse();
           }
 


### PR DESCRIPTION
It took my some time to find out that the order direction is always "descending" as soon as you add the direction comparator. I tried to set the direction to 'ascending', 'asc' and false but nothing helped to change the direction. The solution was to remove the comparator completely.

This pull request allows users to explicitly set an ascending order so that they don't have to remove the comparator completely.

My first thought was to replace 
`if (reverse) {`
with 
`if (reverse === 'descending' || reverse === true) {`
so that users have to set the direction to descending explicitly, otherwise the direction would fall back to 'ascending'.

But the other solution – which I'm submitting with this PR – allows backwards compatibility for users who use the direction comparator but don't use the term 'descending' or true.
