### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#Angular orderObjectBy filter
+# Angular orderObjectBy filter
 
-##Synopsis
+## Synopsis
 
 This filter was [created by **Justin Klemm**](http://justinklemm.com/angularjs-filter-ordering-objects-ngrepeat/) because the default Angular orderBy filter fails to sort properly Objects of Objects in the context of ngRepeat.
 
-##Use
+## Use
 
 Install as Bower dependency: ```bower install angular-order-object-by```.
 
@@ -32,7 +32,7 @@ Thanks to @diegou work now sorting by children's sudocument's properties is supp
 
 For an example see [test/index.html](https://github.com/fmquaglia/ngOrderObjectBy/blob/master/test/index.html).
 
-##Tests
+## Tests
 
 You need [karma](https://www.npmjs.org/package/karma), [karma-cli](https://www.npmjs.com/package/karma-cli), [karma-jasmine](https://www.npmjs.org/package/karma-jasmine), [phantomjs](https://www.npmjs.org/package/phantomjs), [karma-phantom-js-launcher](https://www.npmjs.org/package/karma-phantomjs-launcher) and [angular-mocks](https://www.npmjs.org/package/angular-mocks) in order to run the tests.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
